### PR TITLE
AL-4123 Fix package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "kolypto-flask-jsontools"
+name = "flask-jsontools"
 version = "1.0.0"
 description = "JSON API tools for Flask"
 authors = ["Dignio AS"]


### PR DESCRIPTION
Package name was based on the Github repository name instead of the name that is used when imported into other python projects.

Jira AL-4123
https://dignio.atlassian.net/browse/AL-4123